### PR TITLE
fix: replace `wrapGAppsHook4` with `wrapGAppsHook3`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -48,7 +48,7 @@
   libXScrnSaver,
   makeWrapper,
   copyDesktopItems,
-  wrapGAppsHook4,
+  wrapGAppsHook3,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "zen-browser";
@@ -128,7 +128,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     copyDesktopItems
-    wrapGAppsHook4
+    wrapGAppsHook3
   ];
 
   installPhase = ''


### PR DESCRIPTION
Firefox/Zen Browser still uses GTK3, so `wrapGAppsHook4` made Zen Browser crash, e.g. when opening file chooser
