### PR TITLE
fix: fix FFmpeg version at 7

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -32,7 +32,7 @@
   libnotify,
   cups,
   pciutils,
-  ffmpeg,
+  ffmpeg_7,
   libglvnd,
   pipewire,
   speechd,
@@ -107,7 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
     libnotify
     cups
     pciutils
-    ffmpeg
+    ffmpeg_7
     libglvnd
     pipewire
     speechd


### PR DESCRIPTION
Hey, it's me again :sweat_smile:. FFmpeg 8 lacks codecs required by Zen Browser and as a result, some videos play without sound now